### PR TITLE
Fix Google images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-undefined
+.DS_Store

--- a/scripts/google-images.coffee
+++ b/scripts/google-images.coffee
@@ -40,5 +40,4 @@ imageMe = (msg, query, animated, faces, cb) ->
       images = images.responseData?.results
       if images?.length > 0
         image  = msg.random images
-        cb "#{image.unescapedUrl}#.png"
-
+        cb "#{image.unescapedUrl}"


### PR DESCRIPTION
Looks like our drivebot script was manually adding the #.png, which seems no longer to be required with new Google return value. 
